### PR TITLE
Fix issue with fractionals not being supported.

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -670,7 +670,7 @@ module StreetAddress
 
     self.address_regexp = /
       \A
-      [^\w\x23\/]*    # skip non-word chars except # (eg unit)
+      [^\w\x23]*    # skip non-word chars except # (eg unit)
       #{number_regexp} \W*
       (?:#{fraction_regexp}\W*)?
       #{street_regexp}\W+

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -104,7 +104,7 @@ class AddressTest < Minitest::Test
       :line2 => "Los Angeles, CA"
     },
     "1234 1/3 Fast Road, Los Angeles, CA" => {
-      :line1 => "1234 Fast Rd",
+      :line1 => "1234 1/3 Fast Rd",
       :line2 => "Los Angeles, CA"
     },
     "1 First St, e San Jose CA" => {

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'street_address'
 
-class AddressTest < MiniTest::Test
+class AddressTest < Minitest::Test
   ADDRESSES = {
     "1005 Gravenstein Hwy 95472" => {
       :line1 => "1005 Gravenstein Hwy",
@@ -100,7 +100,11 @@ class AddressTest < MiniTest::Test
       :line2 => "Minneapolis, MN"
     },
     "3813 1/2 Some Road, Los Angeles, CA" => {
-      :line1 => "3813 Some Rd",
+      :line1 => "3813 1/2 Some Rd",
+      :line2 => "Los Angeles, CA"
+    },
+    "1234 1/3 Fast Road, Los Angeles, CA" => {
+      :line1 => "1234 Fast Rd",
       :line2 => "Los Angeles, CA"
     },
     "1 First St, e San Jose CA" => {

--- a/test/street_address_test.rb
+++ b/test/street_address_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'street_address'
 
-class StreetAddressUsTest < MiniTest::Test
+class StreetAddressUsTest < Minitest::Test
   ADDRESSES = {
     "1005 Gravenstein Hwy 95472" => {
       :number => '1005',
@@ -206,7 +206,7 @@ class StreetAddressUsTest < MiniTest::Test
       :prefix => 'SE'
     },
     "3813 1/2 Some Road, Los Angeles, CA" => {
-      :number => '3813',
+      :number => '3813 1/2',
       :street => 'Some',
       :state => 'CA',
       :city => 'Los Angeles',

--- a/test/street_address_test.rb
+++ b/test/street_address_test.rb
@@ -212,6 +212,13 @@ class StreetAddressUsTest < Minitest::Test
       :city => 'Los Angeles',
       :street_type => 'Rd',
     },
+    "1234 1/3 Fast Road, Los Angeles, CA" => {
+      :number => '1234 1/3',
+      :street => 'Fast',
+      :state => 'CA',
+      :city => 'Los Angeles',
+      :street_type => 'Rd',
+    },
     "1 First St, e San Jose CA" => { # lower case city direction
       :number => '1',
       :street => 'First',


### PR DESCRIPTION
adds support for 1/4 & 1/2 addresses to number block. 

removes dead fractional regex and calls to it.

